### PR TITLE
Windows install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcartogram
-Version: 0.2-2
+Version: 0.2-3
 Title: Interface to Mark Newman's cartogram software
-Description:  This is an interface to C code
+Description: Rcartogram is an interface to C code
   for "fitting" diffusion cartograms to a grid
   of densities.  The resulting grid can be used to 
   transform/interpolate values in the original coordinates.
@@ -13,8 +13,15 @@ Description:  This is an interface to C code
   are displayed rather than geographical area.
 Author: Duncan Temple Lang
 Depends: methods
-Maintainer: Duncan Temple Lang <duncan@wald.ucdavis.edu>
+Maintainer: Duncan Temple Lang <duncan@wald.ucdavis.edu> 
 SystemRequirements: libfftw3
+Biarch: TRUE
 License: BSD
 See: http://www-personal.umich.edu/~mejn/cart/
      http://www-personal.umich.edu/~mejn/cart/doc/description.html
+     http://www.omegahat.org/Rcartogram/
+Packaged: Wed Dec 10 10:06:43 2008; duncan
+Imports: maps, methods
+LazyData: true
+Suggests: knitr
+VignetteBuilder: knitr

--- a/R/cart.R
+++ b/R/cart.R
@@ -38,7 +38,7 @@ if(TRUE)  {
    x = as.numeric(x) - 1 
    y = as.numeric(y) - 1
 
-   tmp = .Call("R_makecartogram", popEls, x, y, dim, as.numeric(blur))
+   tmp = .Call("R_makecartogram", popEls, x, y, dim, as.numeric(blur), PACKAGE = "Rcartogram")
      # convert the results into matrices.
    ans = lapply(tmp, function(x) matrix(x, nrow(pop) + zero, ncol(pop) + zero, byrow = TRUE))
    ans = structure(ans,
@@ -89,10 +89,13 @@ function(object, x, y = NULL, ...)
   }
      
   
-  tmp = rep(as.numeric(NA), length(x))
-  ans = list(x = tmp, y = tmp)
-
-  .Call("R_predict", object, as.numeric(x),  as.numeric(y), ans, dim(object$x))
+  # Avoid problems with the same vector (tmp) being sent to C twice due to R's
+  # copy-on-modify rules
+  tmp_x = rep(as.numeric(NA), length(x))
+  tmp_y = rep(as.numeric(NA), length(y))
+  ans = list(x = tmp_x, y = tmp_y)
+  
+  .Call("R_predict", object, as.numeric(x),  as.numeric(y), ans, dim(object$x), PACKAGE = "Rcartogram")
   ans
 }
 

--- a/README.WindowsInstall
+++ b/README.WindowsInstall
@@ -1,0 +1,37 @@
+This is an overview of how to install Rcartogram, from source, on a Windows system.  
+
+See the vignette "README.WindowsInstall.Tutorial.Rmd" or "README.WindowsInstall.Tutorial.html" (in the vignettes sub-directory) for a more extensive set of instructions, an explanation of what the instructions are doing, and some alternative ways of getting Rcartogram installed successfully on a Windows system.
+
+INSTRUCTIONS
+
+There are three basic steps to install Rcartogram from source on a Windows system:
+
+Step 1.
+
+Download and install Rtools.  Rtools is available from [Rtools and the Windows toolset](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-Windows-toolset).  
+
+I find these [user friendly Rtools instructions](https://github.com/stan-dev/rstan/wiki/Install-Rtools-for-Windows) a little easier to follow.
+
+
+Step 2. 
+
+Download and install the FFTW library.  Precompiled FFTW libraries for Windows are available from [FFTW Windows downloads page](http://www.fftw.org/install/windows.html).  You will need **both** 32 bit and 64 bit versions of the library. 
+
+Unzip the 32 bit version onto "somepath"/i386, and the 64 bit version into "somepath"/x64
+
+You can choose any directory you like for "somepath".
+
+Step 3.
+
+Download the latest source code bundle for Rcartogram from the [Omegahat Rcartogram gitHub site](https://github.com/omegahat/Rcartogram), unzip it, start an R console, set the Rcartogram directory as the working directory and enter:
+      
+Sys.setenv(local_LIB_FFTW=shortPathName("somepath"))  
+install.packages(".", repos = NULL, type = "source", INSTALL_opts = "--preclean)  
+Sys.unsetenv("local_LIB_FFTW")  
+    
+where "somepath" is the directory you chose for the FFTW libraries in Step2.
+
+
+Optional Step 4
+
+Once Rcartogram is installed in your R library you can safely tidy up, if you wish, by deleting the downloaded FFTW libraries ("somepath"/i383, "somepath"/x64), and the source code version of Rcartogram which you downloaded. 

--- a/configure.win
+++ b/configure.win
@@ -1,13 +1,23 @@
-
-if test -z "${FFTW3_DIR}" ; then
- echo "You need to set the environment variable FFTW3_DIR to point to the directory containing fftw3.h and libfftw3-3.dll"
- exit 1
+if test -z "${FFTW3_DIR}" -a -z "${LIB_FFTW}" -a -z "${local_LIB_FFTW}" ; then
+ echo ----------------------------------------------------------------------------
+ echo Message from configure.win
+ echo
+ echo To install Rcartogram from source you must have the FFTW libraries installed.
+ echo You also need to tell R where to find the libraries. One way to do this is
+ echo to set the environment variable local_LIB_FFTW to point to the directory
+ echo containing the FFTW libraries.
+ echo
+ echo Download and install the 32 bit FFTW library in "somepath"/i386, and 
+ echo the 64 bit FFTW library into "somepath"/x64.  Then in an R console
+ echo set the working directory to be Rcartogram and enter:
+ echo
+ echo 'Sys.setenv(local_LIB_FFTW=shortPathName("somepath"))'
+ echo 'install.packages(".", repos = NULL, type = "source", INSTALL_opts = "--preclean")'
+ echo 'Sys.unsetenv("local_LIB_FFTW")'
+ echo
+ echo See README.Windowsinstall for details.
+ echo See the README.Windowsinstall.tutorial in the vignettes sub-directory for 
+ echo a full explanation and information about other options.
+ echo ----------------------------------------------------------------------------
 fi
-
-if ! test -r "$R_PACKAGE_DIR/libs" ;  then
-  mkdir "$R_PACKAGE_DIR/libs"
-fi
-
-cp "$FFTW3_DIR/libfftw3-3.dll" "$R_PACKAGE_DIR/libs"
-
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,232 @@
-#FFT3_DIR=../../fftw3
-PKG_CPPFLAGS=-I$(FFTW3_DIR)
-PKG_LIBS=-L$(FFTW3_DIR) -lfftw3-3
+## Only used when installing from source on a Windows machine.
+##
+## Concept copied from the fftw R package, then amended, considerably, to add 
+## instructions for Windows users who are installing from source on Windows.
+##
+## =============================================================================
+## Rcartogram REQUIREMENT
+##
+## It is essential to have the libfftw(3) library available on the system in 
+## order to be able to compile Rcartogram from source.  R will need to find two 
+## files :
+##     a C header file called fftw3.h, and
+##     a compiled library file called something like libfftw3.dll
+## I say "something like" because it might be libfftw3-3.dll, or libfftw3.a, or 
+## even libfftw3-3.a (all of which are "legal" and will be recognised OK.)
+##
+## OBJECTIVE of this makefile
+##
+## The main objective of this Makevars.win file is to ascertain where the library
+## is, and pass that information to the later stages of the installation process
+## via two make variables called PKG_CPPFLAGS and PKG_LIBS.  
+##
+## In addition, if you are using a dynamic (as opposed to a static) linked 
+## library (ie its name ends in .dll rather than .a) the library has to be 
+## available whenever Rcartogram is loaded (eg via `library(Rcartogram)`).
+## Makevars.win will copy the libfftw dll to the appropriate sub-directory in 
+## your R library.
+##
+## By default when installing a package from source on Windows, R tries to install
+## both 32 bit and 64 bit versions of the package.  This makefile supports 
+## `multiarch` installs of Rcartogram on Windows.
+##
+## This makefile can be used to compile Rcartogram from source on Windows locally,
+## on your machine. It is also suitable for use with the Win-builder website service.
+##
+## INSTRUCTIONS for compiling Rcartogram from source on Windows
+##
+## See README.WindowsInstall for instructions about how to use this file.
+##
+## The remainder of the comments in this makefile explain what each step is meant
+## to do.  They are for information only.
+## =============================================================================
+##
+## LIB_FFTW is a make variable provided on Win-builder (and on CRAN windows builds).
+## It points to the directory where the Win-builder libfftw(3) library lives.
+## If Rcartogram is being compiled on Win-builder, this Makevars.win file will use
+## Win-builder's LIB_FFTW to find the libfftw(3) library. 
+##
+## If LIB_FFTW is blank (ie this install is not running on CRAN or Winbuilder,
+## but rather is running on your local machine), you will have to tell R where 
+## to find your local copies of the FFTW library files (both 32 and 
+## 64 bit versions).
+##
+## local_LIB_FFTW is the make variable this Makevars.win uses to point to the top
+## level directory where your copy of the libfftw3 library lives. There should be
+## two sub-directories below this top level directory, namely /i386 and /x64,
+## containing the 32 bit and 64 bit versions of the libfftw3 library.
+##
+## On my machine they were in sub-directories of C:/msys/fftwtest.
+## My 32 bit version is in C:/msys/fftwtest/i386, and my 64 bit version is in
+## C:/msys/fftwtest/x64
+##
+## You can provide the name of your libfftw3 library from within R by using a
+## (temporary) environment variable set via `Sys.setenv(local_LIB_FFTW="<your path>")`
+##
+## An earlier version of this makefile use a variable called FFTW3_DIR for the same
+## purpose. The line below is provided for backwards compatibility. (The variable
+## name was changed to align better with the name of the variable that the 
+## Win-builder website service uses to point to their libfftw3 library.)
+##
+## The "?=" below says only do this assignment if local_LIB_FFTW does not already
+## exist (and note that an environment variable of that same name counts as existing).
+## =============================================================================
+
+local_LIB_FFTW ?= $(FFTW3_DIR)
+
+## =============================================================================
+## R_ARCH is a make variable that R uses when it is installing sub-architectures.
+## On Windows, R_ARCH will be /i386 when installing the 32 bit version, and /x64
+## when installing the 64 bit version.
+##
+## This step ensures that local_LIB_FFTW refers to the appropriate R_ARCH 
+## sub-directory.
+##
+## If R_ARCH is not found in local_LIB_FFTW append it to LIB_FFTW, after
+## removing any trailing spaces (Use the := operator to prevent "make"" thinking  
+## a "recursively defined variable" is referencing itself - ie an error)
+## =============================================================================
+
+ifeq ($(findstring $(strip $(R_ARCH)), $(local_LIB_FFTW)), )
+local_LIB_FFTW :=$(local_LIB_FFTW)$(strip $(R_ARCH))
+endif
+
+## =============================================================================
+## If LIB_FFTW is not already defined, eg by Winbuilder or CRAN, 
+## (that's what ?= does), use the local value, as set above.
+## =============================================================================
+
+LIB_FFTW ?= $(local_LIB_FFTW)
+
+## =============================================================================
+## My own local build of FFTW from source put the header file (fftw3.h)
+## that the C preprocessor needs into a subsubdirectory of "LIB_FFTW" called /include.
+## Likewise the actual FFTW library (called something like libfftw3.<whatever>)
+## is in a subsubdirectory of "LIB_FFTW" called /lib
+##
+## On my system that equates to
+## C:/msys/fftwtest/x64/include, and C:/msys/fftwtest/x64/lib (for the 64 bit)
+## C:/msys/fftwtest/i386/include, and C:/msys/fftwtest/i386/lib (for the 32 bit)
+##
+## An alternative possibility is that there are no such subsubdirectories in 
+## your FFTW library, for example, if you have downloaded precompiled copies of 
+## the FFTW library, ie from
+## http://www.fftw.org/install/windows.html, or if you are planning on using the
+## Win-builder website.  
+##
+## In that case the header file, and the library itself are all in the same 
+## directory.
+##
+## The following step uses 2 make variables to point R towards the
+## sub-sub-directories, but only if they exist.
+##
+## $(wildcard <somepattern>) is a makefile function which returns a list of all 
+## files which match <somepattern>.
+## =============================================================================
+
+local_LIB_FFTW_includedir=/include
+local_LIB_FFTW_libdir=/lib
+
+ifeq ($(wildcard $(LIB_FFTW)$(local_LIB_FFTW_includedir)), )
+	# The include subdirectory was not found, so presume everything is in the same
+	# directory, and "blank" out these variables
+	local_LIB_FFTW_includedir=
+	local_LIB_FFTW_libdir=
+endif
+
+## =============================================================================
+## The compiled binary FFTW library (libraries really since there are 32 and 64 bit
+## versions) is probably called libfftw3.<something>, where <something> is either
+## "dll" or "a".  But sometimes they are called libfftw3-3.<something> (because)
+## FFTW is up to version 3-3). So we need to check and tell R and the C compiler
+## (via this makefile, and a C compiler flag) which library name to look for.  
+## By a convention we drop the "lib" and the .<something> from the value in 
+## the "-l" compiler flag.
+## =============================================================================
+
+## Check and see if a "libfftw3-3...." file exists"
+test_fftw3-3=$(wildcard $(LIB_FFTW)$(local_LIB_FFTW_libdir)/libfftw3-3*)
+
+ifeq ($(test_fftw3-3), )
+local_FFTW_libname=fftw3 # The default
+else
+# We *did* find a file  in the libdir beginning with libfftw3-3 
+# so we'll assume that fftw3-3 is what is needed instead of just fftw3
+local_FFTW_libname=fftw3-3
+endif
+
+## =============================================================================
+## Finally, fill in the make variables that the later parts of the R install
+## process actually want.
+## =============================================================================
+
+PKG_CPPFLAGS=-I"$(LIB_FFTW)$(local_LIB_FFTW_includedir)"
+PKG_LIBS=-L"$(LIB_FFTW)$(local_LIB_FFTW_libdir)" -l$(local_FFTW_libname)
+
+## =============================================================================
+## Finish by adding some dependencies so that the R install process: 
+##     a) copies the fftw3 dll, if FFTW DLLs are provided, and
+##     b) emits a message letting you know what it did.
+##
+## The dependencies are called .local_copy_FFTW_dll, and .local_LIB_FFTW_msg
+##
+## The indented code (recipes) in those  blocks is indented by tabs **NOT** spaces.
+## **NB** It is **CRUCIAL** that the lines remain indented by tabs, NOT spaces.
+## That is how makefiles distinguish recipes from targets and dependencies.
+## If your editor changes tabs to spaces, everything will go severely pear-shaped,
+## and you will get confusing error messages such as "missing separator".
+##
+## PS Don't worry if you see messages like '.local_copy_FFTW_dll': No such file
+## That is supposed to happen.
+## =============================================================================
+
+.PHONY: all .local_LIB_FFTW_msg .local_copy_FFTW_dll
+
+all: $(SHLIB)
+
+$(SHLIB):  .local_copy_FFTW_dll .local_LIB_FFTW_msg 
+
+## =============================================================================
+## If the fftw3 library is a dynamic link library (aka the filename ends in .dll)
+## R will need to find it every time Rcartogram is used.  To ensure that happens,
+## the following makefile rule checks whether the fftw3 library ends in dll, and
+## if it does, copies the fftw3 dll library to the first place R will look for it, 
+## namely the R library (sub-)directory where the rest of the Rcartogram package
+## will be installed.
+## =============================================================================
+
+test_dll =$(LIB_FFTW)$(local_LIB_FFTW_libdir)/lib$(local_FFTW_libname).dll
+
+.local_copy_FFTW_dll:
+ifneq ($(wildcard  $(test_dll)), )
+	## OK, using a dll fftw library so copy it as needed.
+ifeq ($(wildcard $(R_PACKAGE_DIR)/libs$(R_ARCH)), )
+	mkdir -p -v "$(R_PACKAGE_DIR)/libs$(R_ARCH)"
+endif
+	cp "$(LIB_FFTW)$(local_LIB_FFTW_libdir)/lib$(local_FFTW_libname).dll" "$(R_PACKAGE_DIR)/libs$(R_ARCH)"
+endif
+
+## =============================================================================
+## This makefile rule just echoes some messages about what was found and done.
+## =============================================================================
+
+.local_LIB_FFTW_msg:
+	@echo ------------------------------------------------------------------------
+	@echo Information message from src/Makevars.win, no user action required
+	@echo
+	@echo Looking for the \(lib\)fftw\(3\) libraries.
+	@echo FFTW_DIR \(now deprecated\) was set as ...$(FFTW_DIR)...
+	@echo local_LIB_FFTW was set as ...$(local_LIB_FFTW)...
+	@echo LIB_FFTW was set as ...$(LIB_FFTW)...
+	@echo local_LIB_FFTW_includedir was detected as ...$(local_LIB_FFTW_includedir)...
+	@echo local_LIB_FFTW_libdir was detected as ...$(local_LIB_FFTW_libdir)...
+	@echo local_FFTW_libname was set to ...$(local_FFTW_libname)...
+	@echo R_ARCH is ...$(R_ARCH)...
+	@echo Based on all that :
+	@echo PKG_CPPFLAGS was set to $(PKG_CPPFLAGS)
+	@echo and PKG_LIBS was set to $(PKG_LIBS)
+	@echo R_PACKAGE_DIR is $(R_PACKAGE_DIR)
+	@echo Finished looking for the \(lib\)fftw\(3\) libraries. Good luck with the next step.
+	@echo ------------------------------------------------------------------------
+
+

--- a/vignettes/README.WindowsInstall.Tutorial.Rmd
+++ b/vignettes/README.WindowsInstall.Tutorial.Rmd
@@ -1,0 +1,369 @@
+---
+title: "README.WindowsInstall Tutorial"
+author: "Geoff Lee"
+date: "`r strftime(Sys.Date(), '%a %d %b %Y')`"
+output:
+  rmarkdown::html_vignette:
+    toc: yes
+  html_document:
+    toc: yes
+  pdf_document:
+    keep_tex: no
+    latex_engine: pdflatex
+vignette: >
+  %\VignetteIndexEntry{README.WindowsInstall Tutorial}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
+---
+
+# Introduction : Installing Rcartogram from source on Windows
+
+--------------
+
+## Intended audience
+
+This document explains how to install the Rcartogram package from source, on Windows.  It is aimed at novice level.  It includes:
+
+  + instructions about *what* to do, and
+  + explanations about *how* those instructions work, so should something go awry, you have a chance of understanding what is wrong, and recovering from the mistake.  
+
+It is the explanations that make this document long --- you can complete the instructions about what to do in less time than it takes to read this document.  If all you want to do is install Rcartogram, there are three basic steps --- just jump to the section marked "instructions" in each step, and follow the prescription written there.  It is not essential to understand (or even read) the explanations.
+
+If you you *are* curious about how this all works, and do decide to read the explanations as well, it is probably best read in order from the beginning since it has been written in "tutorial style".
+
+## Aside : Formatting in this document
+
+This document has been written to use "markdown" formatting.  If you are reading this as a text file, just ignore the extra backticks, hashes, and asterisks sprinkled through the document - they are formatting instructions. Or if you want to see a "prettier" version, you can use the rmarkdown package (available from CRAN) to render it into a number of other formats. For example, after installing rmarkdown you could open an R console and enter (**without** the backticks - they are part of the formatting ! but **with** the quotes, ", they are part of the R code):
+
+```
+rmarkdown::render("path to this file", output_format = "html_vignette")
+```
+
+to convert it to a nicely formatted html document that can be read in a web browser.
+
+## What does "install from source" mean?
+
+On *Windows*, when a package is installed, eg via `install.packages( ... )` or a drop down menu in the GUI, the default is to install pre-prepared *binary* versions of the package.  As a consequence, many Windows based users of R (eg this author, until recently) are unfamiliar with the other possible ways of installing R packages.  This contrasts with Unix (or \*nix) users of R, for whom the default is to install from *source*.  
+
+"Install from source" means that you begin with the source code, and must compile any C code that is involved into binary (ie internal machine code) form yourself, before you can install the package in your R library.
+
+## Overview of the problem
+
+If a package is written in *pure* R, there is little practical difference between installing from source, and installing from a pre-prepared package bundle --- since there is no C code involved anyway.  
+
+However, Rcartogram is essentially a wrapper of R code around a C program, `cart`, that was written by Mark Newman.  At the time of writing, binary versions of Rcartogram suitable for Windows based systems are not available.  Hence to install Rcartogram on Windows, you have to install from source.  Installing an R package which involves C code from *source* is a little more involved, since tools are needed to compile the C code, and link it to the R code.
+
+For \*nix users, all the necessary tools for installing from source are usually already available on their system, so there is little extra preparation required.  Windows users however have to install the tools needed to install R packages from source onto their system before they can proceed.  
+
+In addition the `cart` program uses an open-source library of subroutines to perform Fourier transforms. The library is called *FFTW* (Fastest Fourier Transform in the West).  Hence for Rcartogram, there is the added complication that you also have to install the FFTW library, and let R know where to find it.
+
+## Basic instructions - 3 steps to install Rcartogram from source
+
+There are three basic steps to install Rcartogram from source on a Windows system:
+
+  + Step 1. Download and install Rtools.  Rtools is available from [Rtools and the Windows toolset](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-Windows-toolset).  I find these [user friendly Rtools instructions](https://github.com/stan-dev/rstan/wiki/Install-Rtools-for-Windows) a little easier to follow.
+  + Step 2. Download and install the FFTW library.  Precompiled FFTW libraries for Windows are available from [FFTW Windows downloads page](http://www.fftw.org/install/windows.html).  You will need **both** 32 bit and 64 bit versions of the library. Unzip the 32 bit version onto "somepath"/i386, and the 64 bit version into "somepath"/x64
+  + Step 3. Download the latest source code bundle for Rcartogram from the [Omegahat Rcartogram gitHub site](https://github.com/omegahat/Rcartogram), unzip it, start an R console, set the Rcartogram directory as the working directory and enter:
+      
+    ```
+    Sys.setenv(local_LIB_FFTW=shortPathName("somepath"))  
+    install.packages(".", repos = NULL, type = "source", INSTALL_opts = "--preclean)  
+    Sys.unsetenv("local_LIB_FFTW")  
+    ```
+    
+    where "somepath" is the directory you chose for the FFTW libraries in Step2.
+  +	*Optional Step 4*. Once Rcartogram is installed in your R library you can safely tidy up, if you wish, by deleting the downloaded FFTW libraries ("somepath"/i383, "somepath"/x64), and the source code version of Rcartogram which you downloaded. 
+
+## Explanations
+
+The remainder of this document explains each of these steps in detail.
+
+Some alternative approaches are described at the end of the document.
+
+# Step 1 : Installing Rtools
+
+----------------------------
+
+## Instructions
+
+The official instructions, and a link to the Rtools themselves are here https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-Windows-toolset.  
+
+The official instructions tell you how to install lots of other stuff as well, that you need if you want to build R itself from source on Windows, or produce package documentation using LaTeX, but you don't need all that stuff to get Rcartogram working.
+
+There are user friendly explanations of how to install Rtools into a Windows system elsewhere on the web --- see for example https://github.com/stan-dev/rstan/wiki/Install-Rtools-for-Windows
+
+## Explanation - Why do you need Rtools?
+
+Rcartogram is a package which includes C code, as well as pure R code. In fact it is mostly C code.   Installing from source for a package which includes C code requires a C compiler.  In fact it is best (almost essential) that it is the same C compiler that was used to build R itself.
+
+That is what Rtools mostly is --- an "installable on Windows" version of the C compiler used to build R.  
+
+Running the C compiler under Windows needs a few extra shell commands (aka small programs) as well and that is what the rest of Rtools is.  Most of the (open source) C community seem to work in a Unix (or variant thereof) world and those extra commands (and indeed the C compiler itself) are part of the “standard” system in Unix.
+
+It’s only those of us who work in Windows who need to install Rtools, which is a port of the necessary tools from Unix to Windows.
+
+# Step 2: Install the FFTW library
+
+----------------------------------
+
+There are two options for obtaining the FFTW library.  The simplest, using pre-compiled FFTW DLLs available for download from the FFTW website, is described here.  An alternative is outlined at the end of this document.
+
+## Instructions
+
+The main FFTW website is [FFTW --- C code for Fast Fourier Transforms](http://www.fftw.org/).  It contains a link to their [FFTW downloads page](http://www.fftw.org/download.html), which in turn contains a link to their [FFTW Windows downloads page](http://www.fftw.org/install/windows.html)
+
+Download both the 32 bit **and** 64 bit versions of the zipped DLL files.  
+
+Unzip the 32 bit version into a directory called "somepath"/i386, and unzip the 64 bit version into a directory called "somepath"/x64.  
+
+"somepath" can be any directory you choose.  
+
+Later on, in step 3 you will tell R what "somepath" is, so it can find the FFTW libraries.
+
+## Explanation - What is a DLL, and why are 32 *and* 64 bit versions necessary?
+
+DLLs are "dynamic linked libraries".  A DLL is a pre-compiled (or binary) version of the FFTW code that other programs (such as `cart` and `Rcartogram`) can link to when they are compiled, and again when they are running.
+
+The zip files contain the actual precompiled library (called `libfftw3-3.dll`). They also contain a C code header file (called `fftw3.h`) which programs like `Rcartogram` need at compile time so they know what the functions provided in the DLL "look like" (in more technical jargon, what their "signatures" are).
+
+By default (at least on my 64 bit system) R tries to install both 32 bit and 64 bit versions of every package.  For pure R code packages there is no difference, so R only installs one version.  But for packages like `Rcartogram` which involve C code, it will look for or create both 32 bit and 64 bit versions of the compiled C code , and install those in separate sub-directories of the R package in your R library.  
+
+When R is installing  `Rcartogram`, it looks for the 32 bit version of the FFTW DLL in the `/i386` sub-directory of "somepath", and the 64 bit version of the FFTW DLL in the `/x64` sub-directory of "somepath" .  `/i386` and `/x64` are standard names that the R install process knows about and uses automatically on Windows.
+
+Because these FFTW DLL libraries are "dynamically linked" R will need to find them at run time, whenever you use the `Rcartogram` package.  The `Rcartogram` install process takes care of this for you, by copying them to the appropriate place in your R library.  If at any stage you see anything similar to the following (extremely confusing) error message:
+
+```
+Error in inDL(x, as.logical(local), as.logical(now), ...) : 
+unable to load shared object '...../Rcartogram/libs/i386/Rcartogram.dll':
+LoadLibrary failure:  The specified module could not be found.
+```
+
+the problem is *NOT* that R cannot find Rcartogram.dll, but rather that while loading Rcartogram, Windows could not find a "specified module" that R asked for, with the specified module being the FFTW library!  The FFTW library must also be for the right architecture (32 or 64 bit).  The example above could not find a 32 bit FFTW library (which can be deduced because it is trying to load the `/i386` version of Rcartogram). It means that something went awry with this copy step (or a preceding FFTW compile step).
+
+# Step 3 Install Rcartogram
+
+---------------------------
+
+## Instructions
+
+To install Rcartogram:
+
+  + Download the source bundle for Rcartogram.  The [Omegahat Rcartogram gitHub site](https://github.com/omegahat/Rcartogram) has the most up to date version. 
+  + Decompress (ie unzip and/or untar) it. Depending upon what version of Windows you are using, and how you download it, you may need a utility program to unzip and untar this file.  I use 7zip, available for free from the [7zip download page](http://www.7-zip.org/download.html).
+  + Start R, navigate to the Rcartogram folder, set it as your working directory, and in the R console enter:
+      
+    ```
+    Sys.setenv(local_LIB_FFTW=shortPathName("somepath"))  
+    install.packages(".", repos = NULL, type = "source", INSTALL_opts = "--preclean")  
+    Sys.unsetenv("local_LIB_FFTW")  
+    ```
+    
+    where "somepath" is the directory you chose for the FFTW libraries in Step2.  In my case, I had `Sys.setenv(local_LIB_FFTW=shortPathName("C:/msys/fftwtest"))` 
+  + or, instead of starting R etc, you could open a `cmd` window, navigate to the Rcartogram folder, and enter (all on one line):
+    
+    ```
+    set local_LIB_PATH=somepath&& R CMD INSTALL --preclean "."
+    ```
+    
+    NB the (lack of) spacing and quoting on this line *is* important, which is why I find it easier to install Rcartogram from within R using `install.packages(...)`
+
+(If you are reading this document in text mode, ignore the "backticks", they are part of the markdown formatting of this document).
+
+
+## Explanations --- install.packages; local_LIB_FFTW; makefiles and src/Makevars.win
+
+### install.packages, and R CMD INSTALL
+
+`install.packages` is the R function which the GUI uses to install packages.  Using it explicitly in the console is the simplest way of using non-default arguments:
+
+  + `".", repos = NULL ` says install the package whose source code is in the current working directory; and do not try and download anything from CRAN or any of the other possible R package repositories.
+  + `type = "source"` says install from source (ie it is not a binary package).
+  + `INSTALL_opts = "--preclean"` passes the preclean flag to a later step in the install process:
+    
+    * `--preclean` says remove any intermediate files from any previous installation steps before beginning.
+
+
+Internally, `install.packages` (effectively) runs the system command `R CMD INSTALL`, hence the equivalence of the the second `cmd` line option above.
+
+### local_LIB_FFTW
+
+The lines of code involving `local_LIB_FFTW` are how you tell R where to find the FFTW libraries it needs.  The line beginning `Sys.setenv(local_LIB_FFTW=...)` creates a temporary environment variable (called `local_LIB_FFTW`), which later parts of the R install process use to find the FFTW libraries.  
+
+The `shortPathName` function (available only on Windows) converts "somepath" into a old-fashioned shorter version of "somepath" that Windows still recognises as the same directory, but which does not have blank spaces anywhere in the (shortened) pathname.  Windows allows pathnames containing spaces but some older Unix commands did not deal well with blanks in pathnames, so I play safe and use the `shortPathName` function to avoid any possibility of those sort of errors. 
+
+The environment variable disappears at the end of your R session (but it is tidy practice to remove it explicitly when the install step has finished using `Sys.unsetenv("local_LIB_FFTW")`)
+
+### Makefiles
+
+As a package user, you do not need to know anything at all about this --- it is all done for you --- only package developers need to know this.  But if you are curious, or in case something goes wrong and you need to figure out how to fix the problem, read on.
+
+The explanation of how R uses `local_LIB_FFTW` to complete the installation process is quite straightforward --- but only **once** you know enough about how: 
+
+  + the Unix based world uses `configure`, `make` and makefiles to improve the portability of programs written on lots of different systems, 
+  + R uses a tailored version of that approach when it installs R packages, and
+  + R makes some special exceptions for installing packages from source on Windows based systems.
+  
+The conventional way of installing programs from source in the Unix world involves a shell script (sort of like a Windows .bat file) called configure, and a program called `make` which reads instructions from a makefile.  "Makefiles" are text files with a special format.  Essentially they contain "rules".  Each rule tells the `make` program how to create and install a file. The file to be created is called a "target".  The next part of the rule is a list of "dependencies" (typically other files that must exist before the target can be created) and finally there are a list of 1 or more "recipes", which are system (shell) commands that will be run to create the target once the dependencies exist.  The make program analyses the makefile to discover the order in which various files must be created, then executes the necessary rules and their recipes in the right order.  Typically recipes say things like (not in this syntax though!): 
+
+  + "run the C pre-processor" (on this file), or 
+  + "run the C compiler" (on this file and create an intermediate object file), or 
+  + "link the following object files into an binary executable", or
+  + "copy the executable file into this directory"
+
+To increase flexibility and readability, the `make` program also recognises and uses "make variables" in a makefile.
+
+This is of course a *gross* simplification, but the concept is correct.  If you want to know a *little* more, see for example [Minimal Make](http://kbroman.org/minimal_make/) and [The Magic behind configure,  make, make install](https://robots.thoughtbot.com/the-magic-behind-configure-make-make-install).
+
+In fact the conventions surrounding configure and make, and the specifications for the syntax of a makefile,  are so strong they are almost a standard, and there are literally books written about them.  There are even programs (autotools) that will generate standard (very flexible, and hence very complex) "configure" and "makefile"s for you!
+
+### src/Makevars.win
+
+Rtools includes a Windows version of a `make` program (ported from Unix), and the `R CMD INSTALL` command uses that `make` to install packages.  Many makefiles are actually just called "Makefile", but the `make` program accepts any name for a makefile, and indeed, will read in and combine several makefiles in one run, if so instructed.  
+
+The `R CMD INSTALL` process uses a standard makefile called "Makeconf" (well "R_HOME/etcR_ARCH/Makeconf" to be precise), which does most of the work of compiling and installing *any* R package.  
+
+But before reading Makeconf, `R CMD INSTALL` reads a package specific makefile called "Makevars" (well "src/Makevars" to be precise).  The idea of the "Makevars" file is that package **developers** can use it to set some make variables (called `PKG_CPPFLAGS` and `PKG_LIBS`) that "Makeconf" expects, to whatever values their particular package needs.  The variables, respectively, contain instructions (flags) for the C pre-processor and link stages of the installation process.
+
+Because Windows is "special" and often needs something different to most Unix systems , if `R CMD INSTALL` (or `install.packages`) detects that it is running on a Windows system, priority will be given to a "src/Makevars.win" if it is found, and the usual (Unix) Makevars file will be ignored.
+
+Rcartogram does have a "Makevars.win" file (you can find it in the src subdirectory), whose main purpose is to find the FFTW library, and put some required information into the `PKG_CPPFLAGS` and `PKG_LIBS` variables.  One way that you, a package **user**, can tell "Makevars.win" where you put the FFTW libraries on your system is via a make variable that is defined and used in Rcartogram's "Makevars.win", called `local_LIB_FFTW`. There are numerous ways of setting a make variable, but one is by creating a system environment variable, of the same name, before invoking the `make` program.  And that is what `Sys.setenv(local_LIB_FFTW=...)` does. 
+
+
+# Alternative approaches supported by Makevars.win
+
+--------------------------------------------------
+
+The "src/Makevars.win" does support other ways of informing R where to find the FFTW libraries.  It is extensively (almost overly) documented, if you care to read it.
+
+## Alternative : Use the Win-Builder website service
+
+There is another quite different approach, which uses the [Win-Builder website service](http://win-builder.r-project.org/), rather than compiling `Rcartogram` locally on your machine.  The Win-Builder website:
+
+  + has the necessary C compiler, 
+  + has (static versions of) the FFTW libraries already installed, and 
+  + provides a make variable (called `LIB_FFTW`) which points to the location of the FFTW libraries.
+  
+"Makevars.win" has been written to recognise and use `LIB_FFTW` if it is present (in preference to `local_LIB_FFTW`), so Rcartogram can be compiled simply by uploading the bundled source code of Rcartogram (with one **crucial** change) to the Win-Builder website site.
+
+This delegates all the work of steps 1 through 3 (ie compiling,  linking, and preparing Windows binary versions of `Rcartogram`) to the service provided by the Winbuilder website.  In a way, this is probably the simplest way of compiling a binary version of Rcartogram that can be installed on a Windows system.  
+
+However the Win-Builder website service is intended more for infrequent use as a testing service by package developers who do *not* have access to a Windows system, rather than for regular use by package users who *do* have Windows, so it should be used only as a last resort, if the 3 step approach already described fails for some reason.
+
+There is one **essential** change you **MUST** make to Rcartogram, before you upload to the Win-Builder website.
+
+In the Rcartogram directory, there is a "DESCRIPTION" file.  This is a text file, one line of which reads
+
+```
+Maintainer: Duncan Temple Lang <duncan@wald.ucdavis.edu>
+```
+
+You **MUST** edit this line to your own name and email address, and resave the "DESCRIPTION" file before using the Win-Builder website, since Win-Builder sends all the follow-up emails to that address.  If it holds the wrong address, it will cause lots of annoyance for everyone!
+
+After you have edited and resaved the DESCRIPTION file, you can either:
+
+  1.  rebundle the Rcartogram source code yourself manually (eg by using the `cmd` line `R CMD build` tool - type `R CMD build --help` for instructions), then upload the compressed file to the Win-Builder website using its web interface, or
+  2.  if you have the devtools package (available from CRAN) installed, you can start R, navigate to the Rcartogram folder, set that as your working directory, and enter into the console the line
+  
+    ```
+    devtools::build_win(".", args = "--no-build-vignettes")
+    ```
+
+The `--no-build-vignettes` flag is necessary in `devtools::build_win` (and in `R CMD build "."  --no-build-vignettes`), since otherwise R attempts to (temporarily) install Rcartogram *locally* so it can build the vignettes *before* uploading to the Win-builder website, which of course fails!
+
+In about 30-60 minutes, all being well, you will receive an email with a link to a temporary (it will be deleted in about 72 hours) directory on the the Win-Builder website where you will find a compiled binary version of Rcartogram, in a zip file.
+
+Download that zip file, start R, and then, from the R console, enter
+
+```
+install.packages("path to the zip file", repos = NULL)
+```
+
+`type = source` is not necessary (in fact would be wrong), because this zip file contains the "usual" binary format files that `install.packages` expects on Windows. 
+
+## An alternative Step 2 : Compile FFTW itself from source
+
+----------------------------------------------------------
+
+Step 2, as described earlier, obtained the FFTW libraries in precompiled binary format from the FFTW website.  This alternative downloads the FFTW source code, and compiles the FFTW libraries locally.  
+
+It enables you to specify that you want static (rather than dynamically loaded) versions of the FFTW libraries.  The principal reason you might be interested in static FFTW libraries is to avoid any possibility of the `LoadLibrary failure:  The specified module could not be found.` error message which arises if Windows cannot find the FFTW DLL's when Rcartogram "asks" for them..  
+
+Compiling Rcartogram and linking to static FFTW libraries reduces slightly the complications later on, when you are actually using Rcartogram, but the gain is not great (since the Rcartogram install process and "Makevars.win" automatically takes care of the main complication involved in using dynamically linked versions of the FFTW libraries).
+
+In general I would not recommend this approach to a novice package installer. It involves more work (hence more possibility for something to go wrong).  
+
+The process is only outlined below - it assumes some knowledge about using command lines shells under Windows.
+
+### 1. Download and decompress the FFTW source code
+
+The main FFTW website [FFTW --- C code for Fast Fourier Transforms](http://www.fftw.org/)  contains a link to their [FFTW downloads page](http://www.fftw.org/download.html), which in turn contains a link which enables you to download a compressed version of the [FFTW source code](http://www.fftw.org/fftw-3.3.4.tar.gz).
+
+Download that source code and decompress it.  Depending upon what version of Windows you are using, you may need a utility program to unzip and untar this file.  I use 7zip, available for free from [7zip download page](http://www.7-zip.org/download.html).
+
+The FFTW website includes instructions about [Compiling FFTW on Windows](http://www.fftw.org/install/windows.html).  You need to install some more tools ported from Unix to Windows onto your computer, so that you can run the :
+
+```
+./configure
+make
+make install
+```
+*magic* incantation that is the standard approach to compiling code in the Unix universe.  
+
+What follows is a modified version of the approach described on the FFTW website (modified because Rtools already provides the C compiler you will need).
+
+### 2. Download and install MSys
+
+Next install MSys on your computer.  This website [MinGW-w64 and MSys](http://www.rioki.org/2013/10/16/mingw-w64.html) contains a clear explanation of installing MinGW-w64 and MSys.  You only need to download and install MSys.  I put my downloaded and unzipped (untarred) version in  "c:/msys". 
+
+Once done, you can invoke the `msys` shell at any time by typing `c:\msys\msys.bat` in a `cmd.exe` console.  This opens a new `msys` console titled "MINGW32".
+
+MSys is another "shell", ported to Windows from the Unix world.  It is tantalizingly similar to the usual Windows `cmd` shell, but with some commands and aspects of the syntax different enough to be confusing (if you are unfamiliar with them, as I was).  The good news is you don't really need to learn much about MSys to use it to install FFTW from source.
+
+### 3. Point MSys at the Rtools C Compiler
+
+Rather than downloading and installing MinGW-w64 (a C compiler), you can simply use the C compiler that comes with Rtools.  You just have to tell the MSys shell where to find it.  Do this by altering a line in the "c:/msys/etc/fstab" file, so it reads as follows:
+
+```
+    C:\Rtools\gcc-4.6.3    /mingw
+```
+Substitute :
+
+  + wherever you installed MSys for "C:/msys" to find the correct "etc/fstab" file, and
+  + wherever Rtools is on your system for "C:/Rtools/gcc-4.6.3" in the line in the fstab file.
+
+This tells the `msys` shell that when it is looking for directory `/mingw`, go to what Windows knows as the `C:\Rtools\gcc-4.6.3` directory.  `/mingw` is where later steps will look for gcc, the GNU C compiler.
+
+### 4. Compile FFTW libraries from source
+
+Open the Msys shell, navigate to where the FFTW source is (use the `cd` command, which works under `msys` shell pretty similarly to the same command under the `cmd` shell), and enter the following lines.
+
+```
+# exit if any error
+set -e
+
+#Use the standard architecture specific subdirectories, ie i386 for 32 bit, and x64 for 64 bit, in the prefixes.
+
+#64 bit version
+
+./configure CC="/mingw/bin/gcc -m64" --prefix=/fftwtest/x64 --host=x86_64-w64-mingw32 --disable-alloca --with-our-malloc --with-windows-f77-mangling --disable-shared --enable-static --enable-threads --with-combined-threads --enable-sse2 --with-incoming-stack-boundary=2 && make -j4 && make install
+
+#32 bit version
+
+./configure CC="/mingw/bin/gcc -m32" --prefix=/fftwtest/i386 --host=i386-w64-mingw32 --disable-alloca --with-our-malloc --with-windows-f77-mangling --disable-shared --enable-static --enable-threads --with-combined-threads --enable-sse2 --with-incoming-stack-boundary=2 && make -j4 && make install
+
+```
+To avoid typing errors, you could create a file in the FFTW directory (I called mine "geoffsfftw.txt"), cut and paste these lines into the file, and then execute it from the `msys` shell by entering `./geoffsfftw.txt`  **NB** The sections beginning `./configure` through to `make install` all belong on a **single** line.  In the text above they are wrapped, purely for readability purposes.
+
+This will compile both 32 and 64 bit versions of FFTW, as static libraries.  It takes a while, and emits a lot of messages - there is easily time to take a break and have a cup of coffee or tea while the process is running.
+
+Most of the flags and instructions are copied verbatim from the the FFTW website instructions.  The main differences are:
+
+
+  + the `-m64` in `CC="/mingw/bin/gcc -m64"` tells the C compiler to compile 64 bit versions of the libraries; likewise `-m32` is for the 32 bit version.  This is the feature that took me longest to discover.
+  + `--prefix=/fftwtest/x64` and `--prefix=/fftwtest/i386` tell the make and make install processes where to place the FFTW libraries. These paths are relative to where msys is installed (so on my set up, an example of an absolute location was `c:/msys/fftwtest/x64`)
+  + the `--disable-shared --enable-static` flags say to compile and install static (rather than dynamic linked) versions of the FFTW libraries.
+
+### 5. Continue to Step 3 (as before), to install Rcartogram 
+
+Rcartogram will compile and install quite happily using these static FFTW libraries as input to Step 3, described earlier.  Just set the environment variable `local_LIB_FFTW` to point to the first part (excluding the architecture specific sub-directory) of the prefix - in my example I set `local_LIB_FFTW` to be `c:/msys/fftwtest`. The "src/Makevars.win" file even recognises and automatically takes care of the fact that under the GNU standard layout for files, there may be separate sub-directories below the architecture specific prefix level ("/include" for include files, "/lib" for library files, and so forth).
+ 

--- a/vignettes/README.WindowsInstall.Tutorial.html
+++ b/vignettes/README.WindowsInstall.Tutorial.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+
+<meta name="author" content="Geoff Lee" />
+
+
+<title>README.WindowsInstall Tutorial</title>
+
+
+
+
+<link href="data:text/css,body%20%7B%0A%20%20background%2Dcolor%3A%20%23fff%3B%0A%20%20margin%3A%201em%20auto%3B%0A%20%20max%2Dwidth%3A%20700px%3B%0A%20%20overflow%3A%20visible%3B%0A%20%20padding%2Dleft%3A%202em%3B%0A%20%20padding%2Dright%3A%202em%3B%0A%20%20font%2Dfamily%3A%20%22Open%20Sans%22%2C%20%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans%2Dserif%3B%0A%20%20font%2Dsize%3A%2014px%3B%0A%20%20line%2Dheight%3A%201%2E35%3B%0A%7D%0A%0A%23header%20%7B%0A%20%20text%2Dalign%3A%20center%3B%0A%7D%0A%0A%23TOC%20%7B%0A%20%20clear%3A%20both%3B%0A%20%20margin%3A%200%200%2010px%2010px%3B%0A%20%20padding%3A%204px%3B%0A%20%20width%3A%20400px%3B%0A%20%20border%3A%201px%20solid%20%23CCCCCC%3B%0A%20%20border%2Dradius%3A%205px%3B%0A%0A%20%20background%2Dcolor%3A%20%23f6f6f6%3B%0A%20%20font%2Dsize%3A%2013px%3B%0A%20%20line%2Dheight%3A%201%2E3%3B%0A%7D%0A%20%20%23TOC%20%2Etoctitle%20%7B%0A%20%20%20%20font%2Dweight%3A%20bold%3B%0A%20%20%20%20font%2Dsize%3A%2015px%3B%0A%20%20%20%20margin%2Dleft%3A%205px%3B%0A%20%20%7D%0A%0A%20%20%23TOC%20ul%20%7B%0A%20%20%20%20padding%2Dleft%3A%2040px%3B%0A%20%20%20%20margin%2Dleft%3A%20%2D1%2E5em%3B%0A%20%20%20%20margin%2Dtop%3A%205px%3B%0A%20%20%20%20margin%2Dbottom%3A%205px%3B%0A%20%20%7D%0A%20%20%23TOC%20ul%20ul%20%7B%0A%20%20%20%20margin%2Dleft%3A%20%2D2em%3B%0A%20%20%7D%0A%20%20%23TOC%20li%20%7B%0A%20%20%20%20line%2Dheight%3A%2016px%3B%0A%20%20%7D%0A%0Atable%20%7B%0A%20%20margin%3A%201em%20auto%3B%0A%20%20border%2Dwidth%3A%201px%3B%0A%20%20border%2Dcolor%3A%20%23DDDDDD%3B%0A%20%20border%2Dstyle%3A%20outset%3B%0A%20%20border%2Dcollapse%3A%20collapse%3B%0A%7D%0Atable%20th%20%7B%0A%20%20border%2Dwidth%3A%202px%3B%0A%20%20padding%3A%205px%3B%0A%20%20border%2Dstyle%3A%20inset%3B%0A%7D%0Atable%20td%20%7B%0A%20%20border%2Dwidth%3A%201px%3B%0A%20%20border%2Dstyle%3A%20inset%3B%0A%20%20line%2Dheight%3A%2018px%3B%0A%20%20padding%3A%205px%205px%3B%0A%7D%0Atable%2C%20table%20th%2C%20table%20td%20%7B%0A%20%20border%2Dleft%2Dstyle%3A%20none%3B%0A%20%20border%2Dright%2Dstyle%3A%20none%3B%0A%7D%0Atable%20thead%2C%20table%20tr%2Eeven%20%7B%0A%20%20background%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0A%0Ap%20%7B%0A%20%20margin%3A%200%2E5em%200%3B%0A%7D%0A%0Ablockquote%20%7B%0A%20%20background%2Dcolor%3A%20%23f6f6f6%3B%0A%20%20padding%3A%200%2E25em%200%2E75em%3B%0A%7D%0A%0Ahr%20%7B%0A%20%20border%2Dstyle%3A%20solid%3B%0A%20%20border%3A%20none%3B%0A%20%20border%2Dtop%3A%201px%20solid%20%23777%3B%0A%20%20margin%3A%2028px%200%3B%0A%7D%0A%0Adl%20%7B%0A%20%20margin%2Dleft%3A%200%3B%0A%7D%0A%20%20dl%20dd%20%7B%0A%20%20%20%20margin%2Dbottom%3A%2013px%3B%0A%20%20%20%20margin%2Dleft%3A%2013px%3B%0A%20%20%7D%0A%20%20dl%20dt%20%7B%0A%20%20%20%20font%2Dweight%3A%20bold%3B%0A%20%20%7D%0A%0Aul%20%7B%0A%20%20margin%2Dtop%3A%200%3B%0A%7D%0A%20%20ul%20li%20%7B%0A%20%20%20%20list%2Dstyle%3A%20circle%20outside%3B%0A%20%20%7D%0A%20%20ul%20ul%20%7B%0A%20%20%20%20margin%2Dbottom%3A%200%3B%0A%20%20%7D%0A%0Apre%2C%20code%20%7B%0A%20%20background%2Dcolor%3A%20%23f7f7f7%3B%0A%20%20border%2Dradius%3A%203px%3B%0A%20%20color%3A%20%23333%3B%0A%7D%0Apre%20%7B%0A%20%20white%2Dspace%3A%20pre%2Dwrap%3B%20%20%20%20%2F%2A%20Wrap%20long%20lines%20%2A%2F%0A%20%20border%2Dradius%3A%203px%3B%0A%20%20margin%3A%205px%200px%2010px%200px%3B%0A%20%20padding%3A%2010px%3B%0A%7D%0Apre%3Anot%28%5Bclass%5D%29%20%7B%0A%20%20background%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0A%0Acode%20%7B%0A%20%20font%2Dfamily%3A%20Consolas%2C%20Monaco%2C%20%27Courier%20New%27%2C%20monospace%3B%0A%20%20font%2Dsize%3A%2085%25%3B%0A%7D%0Ap%20%3E%20code%2C%20li%20%3E%20code%20%7B%0A%20%20padding%3A%202px%200px%3B%0A%7D%0A%0Adiv%2Efigure%20%7B%0A%20%20text%2Dalign%3A%20center%3B%0A%7D%0Aimg%20%7B%0A%20%20background%2Dcolor%3A%20%23FFFFFF%3B%0A%20%20padding%3A%202px%3B%0A%20%20border%3A%201px%20solid%20%23DDDDDD%3B%0A%20%20border%2Dradius%3A%203px%3B%0A%20%20border%3A%201px%20solid%20%23CCCCCC%3B%0A%20%20margin%3A%200%205px%3B%0A%7D%0A%0Ah1%20%7B%0A%20%20margin%2Dtop%3A%200%3B%0A%20%20font%2Dsize%3A%2035px%3B%0A%20%20line%2Dheight%3A%2040px%3B%0A%7D%0A%0Ah2%20%7B%0A%20%20border%2Dbottom%3A%204px%20solid%20%23f7f7f7%3B%0A%20%20padding%2Dtop%3A%2010px%3B%0A%20%20padding%2Dbottom%3A%202px%3B%0A%20%20font%2Dsize%3A%20145%25%3B%0A%7D%0A%0Ah3%20%7B%0A%20%20border%2Dbottom%3A%202px%20solid%20%23f7f7f7%3B%0A%20%20padding%2Dtop%3A%2010px%3B%0A%20%20font%2Dsize%3A%20120%25%3B%0A%7D%0A%0Ah4%20%7B%0A%20%20border%2Dbottom%3A%201px%20solid%20%23f7f7f7%3B%0A%20%20margin%2Dleft%3A%208px%3B%0A%20%20font%2Dsize%3A%20105%25%3B%0A%7D%0A%0Ah5%2C%20h6%20%7B%0A%20%20border%2Dbottom%3A%201px%20solid%20%23ccc%3B%0A%20%20font%2Dsize%3A%20105%25%3B%0A%7D%0A%0Aa%20%7B%0A%20%20color%3A%20%230033dd%3B%0A%20%20text%2Ddecoration%3A%20none%3B%0A%7D%0A%20%20a%3Ahover%20%7B%0A%20%20%20%20color%3A%20%236666ff%3B%20%7D%0A%20%20a%3Avisited%20%7B%0A%20%20%20%20color%3A%20%23800080%3B%20%7D%0A%20%20a%3Avisited%3Ahover%20%7B%0A%20%20%20%20color%3A%20%23BB00BB%3B%20%7D%0A%20%20a%5Bhref%5E%3D%22http%3A%22%5D%20%7B%0A%20%20%20%20text%2Ddecoration%3A%20underline%3B%20%7D%0A%20%20a%5Bhref%5E%3D%22https%3A%22%5D%20%7B%0A%20%20%20%20text%2Ddecoration%3A%20underline%3B%20%7D%0A%0A%2F%2A%20Class%20described%20in%20https%3A%2F%2Fbenjeffrey%2Ecom%2Fposts%2Fpandoc%2Dsyntax%2Dhighlighting%2Dcss%0A%20%20%20Colours%20from%20https%3A%2F%2Fgist%2Egithub%2Ecom%2Frobsimmons%2F1172277%20%2A%2F%0A%0Acode%20%3E%20span%2Ekw%20%7B%20color%3A%20%23555%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%2F%2A%20Keyword%20%2A%2F%0Acode%20%3E%20span%2Edt%20%7B%20color%3A%20%23902000%3B%20%7D%20%2F%2A%20DataType%20%2A%2F%0Acode%20%3E%20span%2Edv%20%7B%20color%3A%20%2340a070%3B%20%7D%20%2F%2A%20DecVal%20%28decimal%20values%29%20%2A%2F%0Acode%20%3E%20span%2Ebn%20%7B%20color%3A%20%23d14%3B%20%7D%20%2F%2A%20BaseN%20%2A%2F%0Acode%20%3E%20span%2Efl%20%7B%20color%3A%20%23d14%3B%20%7D%20%2F%2A%20Float%20%2A%2F%0Acode%20%3E%20span%2Ech%20%7B%20color%3A%20%23d14%3B%20%7D%20%2F%2A%20Char%20%2A%2F%0Acode%20%3E%20span%2Est%20%7B%20color%3A%20%23d14%3B%20%7D%20%2F%2A%20String%20%2A%2F%0Acode%20%3E%20span%2Eco%20%7B%20color%3A%20%23888888%3B%20font%2Dstyle%3A%20italic%3B%20%7D%20%2F%2A%20Comment%20%2A%2F%0Acode%20%3E%20span%2Eot%20%7B%20color%3A%20%23007020%3B%20%7D%20%2F%2A%20OtherToken%20%2A%2F%0Acode%20%3E%20span%2Eal%20%7B%20color%3A%20%23ff0000%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%2F%2A%20AlertToken%20%2A%2F%0Acode%20%3E%20span%2Efu%20%7B%20color%3A%20%23900%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%2F%2A%20Function%20calls%20%2A%2F%20%0Acode%20%3E%20span%2Eer%20%7B%20color%3A%20%23a61717%3B%20background%2Dcolor%3A%20%23e3d2d2%3B%20%7D%20%2F%2A%20ErrorTok%20%2A%2F%0A%0A" rel="stylesheet" type="text/css" />
+
+</head>
+
+<body>
+
+
+
+<div id="header">
+<h1 class="title">README.WindowsInstall Tutorial</h1>
+<h4 class="author"><em>Geoff Lee</em></h4>
+<h4 class="date"><em>Sun 23 Aug 2015</em></h4>
+</div>
+
+<div id="TOC">
+<ul>
+<li><a href="#introduction-installing-rcartogram-from-source-on-windows">Introduction : Installing Rcartogram from source on Windows</a><ul>
+<li><a href="#intended-audience">Intended audience</a></li>
+<li><a href="#aside-formatting-in-this-document">Aside : Formatting in this document</a></li>
+<li><a href="#what-does-install-from-source-mean">What does “install from source” mean?</a></li>
+<li><a href="#overview-of-the-problem">Overview of the problem</a></li>
+<li><a href="#basic-instructions---3-steps-to-install-rcartogram-from-source">Basic instructions - 3 steps to install Rcartogram from source</a></li>
+<li><a href="#explanations">Explanations</a></li>
+</ul></li>
+<li><a href="#step-1-installing-rtools">Step 1 : Installing Rtools</a><ul>
+<li><a href="#instructions">Instructions</a></li>
+<li><a href="#explanation---why-do-you-need-rtools">Explanation - Why do you need Rtools?</a></li>
+</ul></li>
+<li><a href="#step-2-install-the-fftw-library">Step 2: Install the FFTW library</a><ul>
+<li><a href="#instructions-1">Instructions</a></li>
+<li><a href="#explanation---what-is-a-dll-and-why-are-32-and-64-bit-versions-necessary">Explanation - What is a DLL, and why are 32 <em>and</em> 64 bit versions necessary?</a></li>
+</ul></li>
+<li><a href="#step-3-install-rcartogram">Step 3 Install Rcartogram</a><ul>
+<li><a href="#instructions-2">Instructions</a></li>
+<li><a href="#explanations-install.packages-local_lib_fftw-makefiles-and-srcmakevars.win">Explanations — install.packages; local_LIB_FFTW; makefiles and src/Makevars.win</a><ul>
+<li><a href="#install.packages-and-r-cmd-install">install.packages, and R CMD INSTALL</a></li>
+<li><a href="#local_lib_fftw">local_LIB_FFTW</a></li>
+<li><a href="#makefiles">Makefiles</a></li>
+<li><a href="#srcmakevars.win">src/Makevars.win</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#alternative-approaches-supported-by-makevars.win">Alternative approaches supported by Makevars.win</a><ul>
+<li><a href="#alternative-use-the-win-builder-website-service">Alternative : Use the Win-Builder website service</a></li>
+<li><a href="#an-alternative-step-2-compile-fftw-itself-from-source">An alternative Step 2 : Compile FFTW itself from source</a><ul>
+<li><a href="#download-and-decompress-the-fftw-source-code">1. Download and decompress the FFTW source code</a></li>
+<li><a href="#download-and-install-msys">2. Download and install MSys</a></li>
+<li><a href="#point-msys-at-the-rtools-c-compiler">3. Point MSys at the Rtools C Compiler</a></li>
+<li><a href="#compile-fftw-libraries-from-source">4. Compile FFTW libraries from source</a></li>
+<li><a href="#continue-to-step-3-as-before-to-install-rcartogram">5. Continue to Step 3 (as before), to install Rcartogram</a></li>
+</ul></li>
+</ul></li>
+</ul>
+</div>
+
+<div id="introduction-installing-rcartogram-from-source-on-windows" class="section level1">
+<h1>Introduction : Installing Rcartogram from source on Windows</h1>
+<hr />
+<div id="intended-audience" class="section level2">
+<h2>Intended audience</h2>
+<p>This document explains how to install the Rcartogram package from source, on Windows. It is aimed at novice level. It includes:</p>
+<ul>
+<li>instructions about <em>what</em> to do, and</li>
+<li>explanations about <em>how</em> those instructions work, so should something go awry, you have a chance of understanding what is wrong, and recovering from the mistake.</li>
+</ul>
+<p>It is the explanations that make this document long — you can complete the instructions about what to do in less time than it takes to read this document. If all you want to do is install Rcartogram, there are three basic steps — just jump to the section marked “instructions” in each step, and follow the prescription written there. It is not essential to understand (or even read) the explanations.</p>
+<p>If you you <em>are</em> curious about how this all works, and do decide to read the explanations as well, it is probably best read in order from the beginning since it has been written in “tutorial style”.</p>
+</div>
+<div id="aside-formatting-in-this-document" class="section level2">
+<h2>Aside : Formatting in this document</h2>
+<p>This document has been written to use “markdown” formatting. If you are reading this as a text file, just ignore the extra backticks, hashes, and asterisks sprinkled through the document - they are formatting instructions. Or if you want to see a “prettier” version, you can use the rmarkdown package (available from CRAN) to render it into a number of other formats. For example, after installing rmarkdown you could open an R console and enter (<strong>without</strong> the backticks - they are part of the formatting ! but <strong>with</strong> the quotes, “, they are part of the R code):</p>
+<pre><code>rmarkdown::render(&quot;path to this file&quot;, output_format = &quot;html_vignette&quot;)</code></pre>
+<p>to convert it to a nicely formatted html document that can be read in a web browser.</p>
+</div>
+<div id="what-does-install-from-source-mean" class="section level2">
+<h2>What does “install from source” mean?</h2>
+<p>On <em>Windows</em>, when a package is installed, eg via <code>install.packages( ... )</code> or a drop down menu in the GUI, the default is to install pre-prepared <em>binary</em> versions of the package. As a consequence, many Windows based users of R (eg this author, until recently) are unfamiliar with the other possible ways of installing R packages. This contrasts with Unix (or *nix) users of R, for whom the default is to install from <em>source</em>.</p>
+<p>“Install from source” means that you begin with the source code, and must compile any C code that is involved into binary (ie internal machine code) form yourself, before you can install the package in your R library.</p>
+</div>
+<div id="overview-of-the-problem" class="section level2">
+<h2>Overview of the problem</h2>
+<p>If a package is written in <em>pure</em> R, there is little practical difference between installing from source, and installing from a pre-prepared package bundle — since there is no C code involved anyway.</p>
+<p>However, Rcartogram is essentially a wrapper of R code around a C program, <code>cart</code>, that was written by Mark Newman. At the time of writing, binary versions of Rcartogram suitable for Windows based systems are not available. Hence to install Rcartogram on Windows, you have to install from source. Installing an R package which involves C code from <em>source</em> is a little more involved, since tools are needed to compile the C code, and link it to the R code.</p>
+<p>For *nix users, all the necessary tools for installing from source are usually already available on their system, so there is little extra preparation required. Windows users however have to install the tools needed to install R packages from source onto their system before they can proceed.</p>
+<p>In addition the <code>cart</code> program uses an open-source library of subroutines to perform Fourier transforms. The library is called <em>FFTW</em> (Fastest Fourier Transform in the West). Hence for Rcartogram, there is the added complication that you also have to install the FFTW library, and let R know where to find it.</p>
+</div>
+<div id="basic-instructions---3-steps-to-install-rcartogram-from-source" class="section level2">
+<h2>Basic instructions - 3 steps to install Rcartogram from source</h2>
+<p>There are three basic steps to install Rcartogram from source on a Windows system:</p>
+<ul>
+<li>Step 1. Download and install Rtools. Rtools is available from <a href="https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-Windows-toolset">Rtools and the Windows toolset</a>. I find these <a href="https://github.com/stan-dev/rstan/wiki/Install-Rtools-for-Windows">user friendly Rtools instructions</a> a little easier to follow.</li>
+<li>Step 2. Download and install the FFTW library. Precompiled FFTW libraries for Windows are available from <a href="http://www.fftw.org/install/windows.html">FFTW Windows downloads page</a>. You will need <strong>both</strong> 32 bit and 64 bit versions of the library. Unzip the 32 bit version onto “somepath”/i386, and the 64 bit version into “somepath”/x64</li>
+<li><p>Step 3. Download the latest source code bundle for Rcartogram from the <a href="https://github.com/omegahat/Rcartogram">Omegahat Rcartogram gitHub site</a>, unzip it, start an R console, set the Rcartogram directory as the working directory and enter:</p>
+<pre><code>Sys.setenv(local_LIB_FFTW=shortPathName(&quot;somepath&quot;))  
+install.packages(&quot;.&quot;, repos = NULL, type = &quot;source&quot;, INSTALL_opts = &quot;--preclean)  
+Sys.unsetenv(&quot;local_LIB_FFTW&quot;)  </code></pre>
+where “somepath” is the directory you chose for the FFTW libraries in Step2.</li>
+<li><p><em>Optional Step 4</em>. Once Rcartogram is installed in your R library you can safely tidy up, if you wish, by deleting the downloaded FFTW libraries (“somepath”/i383, “somepath”/x64), and the source code version of Rcartogram which you downloaded.</p></li>
+</ul>
+</div>
+<div id="explanations" class="section level2">
+<h2>Explanations</h2>
+<p>The remainder of this document explains each of these steps in detail.</p>
+<p>Some alternative approaches are described at the end of the document.</p>
+</div>
+</div>
+<div id="step-1-installing-rtools" class="section level1">
+<h1>Step 1 : Installing Rtools</h1>
+<hr />
+<div id="instructions" class="section level2">
+<h2>Instructions</h2>
+<p>The official instructions, and a link to the Rtools themselves are here <a href="https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-Windows-toolset" class="uri">https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-Windows-toolset</a>.</p>
+<p>The official instructions tell you how to install lots of other stuff as well, that you need if you want to build R itself from source on Windows, or produce package documentation using LaTeX, but you don’t need all that stuff to get Rcartogram working.</p>
+<p>There are user friendly explanations of how to install Rtools into a Windows system elsewhere on the web — see for example <a href="https://github.com/stan-dev/rstan/wiki/Install-Rtools-for-Windows" class="uri">https://github.com/stan-dev/rstan/wiki/Install-Rtools-for-Windows</a></p>
+</div>
+<div id="explanation---why-do-you-need-rtools" class="section level2">
+<h2>Explanation - Why do you need Rtools?</h2>
+<p>Rcartogram is a package which includes C code, as well as pure R code. In fact it is mostly C code. Installing from source for a package which includes C code requires a C compiler. In fact it is best (almost essential) that it is the same C compiler that was used to build R itself.</p>
+<p>That is what Rtools mostly is — an “installable on Windows” version of the C compiler used to build R.</p>
+<p>Running the C compiler under Windows needs a few extra shell commands (aka small programs) as well and that is what the rest of Rtools is. Most of the (open source) C community seem to work in a Unix (or variant thereof) world and those extra commands (and indeed the C compiler itself) are part of the â<U+0080><U+009C>standardâ<U+0080> system in Unix.</p>
+<p>Itâ<U+0080><U+0099>s only those of us who work in Windows who need to install Rtools, which is a port of the necessary tools from Unix to Windows.</p>
+</div>
+</div>
+<div id="step-2-install-the-fftw-library" class="section level1">
+<h1>Step 2: Install the FFTW library</h1>
+<hr />
+<p>There are two options for obtaining the FFTW library. The simplest, using pre-compiled FFTW DLLs available for download from the FFTW website, is described here. An alternative is outlined at the end of this document.</p>
+<div id="instructions-1" class="section level2">
+<h2>Instructions</h2>
+<p>The main FFTW website is <a href="http://www.fftw.org/">FFTW — C code for Fast Fourier Transforms</a>. It contains a link to their <a href="http://www.fftw.org/download.html">FFTW downloads page</a>, which in turn contains a link to their <a href="http://www.fftw.org/install/windows.html">FFTW Windows downloads page</a></p>
+<p>Download both the 32 bit <strong>and</strong> 64 bit versions of the zipped DLL files.</p>
+<p>Unzip the 32 bit version into a directory called “somepath”/i386, and unzip the 64 bit version into a directory called “somepath”/x64.</p>
+<p>“somepath” can be any directory you choose.</p>
+<p>Later on, in step 3 you will tell R what “somepath” is, so it can find the FFTW libraries.</p>
+</div>
+<div id="explanation---what-is-a-dll-and-why-are-32-and-64-bit-versions-necessary" class="section level2">
+<h2>Explanation - What is a DLL, and why are 32 <em>and</em> 64 bit versions necessary?</h2>
+<p>DLLs are “dynamic linked libraries”. A DLL is a pre-compiled (or binary) version of the FFTW code that other programs (such as <code>cart</code> and <code>Rcartogram</code>) can link to when they are compiled, and again when they are running.</p>
+<p>The zip files contain the actual precompiled library (called <code>libfftw3-3.dll</code>). They also contain a C code header file (called <code>fftw3.h</code>) which programs like <code>Rcartogram</code> need at compile time so they know what the functions provided in the DLL “look like” (in more technical jargon, what their “signatures” are).</p>
+<p>By default (at least on my 64 bit system) R tries to install both 32 bit and 64 bit versions of every package. For pure R code packages there is no difference, so R only installs one version. But for packages like <code>Rcartogram</code> which involve C code, it will look for or create both 32 bit and 64 bit versions of the compiled C code , and install those in separate sub-directories of the R package in your R library.</p>
+<p>When R is installing <code>Rcartogram</code>, it looks for the 32 bit version of the FFTW DLL in the <code>/i386</code> sub-directory of “somepath”, and the 64 bit version of the FFTW DLL in the <code>/x64</code> sub-directory of “somepath” . <code>/i386</code> and <code>/x64</code> are standard names that the R install process knows about and uses automatically on Windows.</p>
+<p>Because these FFTW DLL libraries are “dynamically linked” R will need to find them at run time, whenever you use the <code>Rcartogram</code> package. The <code>Rcartogram</code> install process takes care of this for you, by copying them to the appropriate place in your R library. If at any stage you see anything similar to the following (extremely confusing) error message:</p>
+<pre><code>Error in inDL(x, as.logical(local), as.logical(now), ...) : 
+unable to load shared object '...../Rcartogram/libs/i386/Rcartogram.dll':
+LoadLibrary failure:  The specified module could not be found.</code></pre>
+<p>the problem is <em>NOT</em> that R cannot find Rcartogram.dll, but rather that while loading Rcartogram, Windows could not find a “specified module” that R asked for, with the specified module being the FFTW library! The FFTW library must also be for the right architecture (32 or 64 bit). The example above could not find a 32 bit FFTW library (which can be deduced because it is trying to load the <code>/i386</code> version of Rcartogram). It means that something went awry with this copy step (or a preceding FFTW compile step).</p>
+</div>
+</div>
+<div id="step-3-install-rcartogram" class="section level1">
+<h1>Step 3 Install Rcartogram</h1>
+<hr />
+<div id="instructions-2" class="section level2">
+<h2>Instructions</h2>
+<p>To install Rcartogram:</p>
+<ul>
+<li>Download the source bundle for Rcartogram. The <a href="https://github.com/omegahat/Rcartogram">Omegahat Rcartogram gitHub site</a> has the most up to date version.</li>
+<li>Decompress (ie unzip and/or untar) it. Depending upon what version of Windows you are using, and how you download it, you may need a utility program to unzip and untar this file. I use 7zip, available for free from the <a href="http://www.7-zip.org/download.html">7zip download page</a>.</li>
+<li><p>Start R, navigate to the Rcartogram folder, set it as your working directory, and in the R console enter:</p>
+<pre><code>Sys.setenv(local_LIB_FFTW=shortPathName(&quot;somepath&quot;))  
+install.packages(&quot;.&quot;, repos = NULL, type = &quot;source&quot;, INSTALL_opts = &quot;--preclean&quot;)  
+Sys.unsetenv(&quot;local_LIB_FFTW&quot;)  </code></pre>
+where “somepath” is the directory you chose for the FFTW libraries in Step2. In my case, I had <code>Sys.setenv(local_LIB_FFTW=shortPathName(&quot;C:/msys/fftwtest&quot;))</code></li>
+<li><p>or, instead of starting R etc, you could open a <code>cmd</code> window, navigate to the Rcartogram folder, and enter (all on one line):</p>
+<pre><code>set local_LIB_PATH=somepath&amp;&amp; R CMD INSTALL --preclean &quot;.&quot;</code></pre>
+<p>NB the (lack of) spacing and quoting on this line <em>is</em> important, which is why I find it easier to install Rcartogram from within R using <code>install.packages(...)</code></p></li>
+</ul>
+<p>(If you are reading this document in text mode, ignore the “backticks”, they are part of the markdown formatting of this document).</p>
+</div>
+<div id="explanations-install.packages-local_lib_fftw-makefiles-and-srcmakevars.win" class="section level2">
+<h2>Explanations — install.packages; local_LIB_FFTW; makefiles and src/Makevars.win</h2>
+<div id="install.packages-and-r-cmd-install" class="section level3">
+<h3>install.packages, and R CMD INSTALL</h3>
+<p><code>install.packages</code> is the R function which the GUI uses to install packages. Using it explicitly in the console is the simplest way of using non-default arguments:</p>
+<ul>
+<li><code>&quot;.&quot;, repos = NULL</code> says install the package whose source code is in the current working directory; and do not try and download anything from CRAN or any of the other possible R package repositories.</li>
+<li><code>type = &quot;source&quot;</code> says install from source (ie it is not a binary package).</li>
+<li><p><code>INSTALL_opts = &quot;--preclean&quot;</code> passes the preclean flag to a later step in the install process:</p>
+<ul>
+<li><code>--preclean</code> says remove any intermediate files from any previous installation steps before beginning.</li>
+</ul></li>
+</ul>
+<p>Internally, <code>install.packages</code> (effectively) runs the system command <code>R CMD INSTALL</code>, hence the equivalence of the the second <code>cmd</code> line option above.</p>
+</div>
+<div id="local_lib_fftw" class="section level3">
+<h3>local_LIB_FFTW</h3>
+<p>The lines of code involving <code>local_LIB_FFTW</code> are how you tell R where to find the FFTW libraries it needs. The line beginning <code>Sys.setenv(local_LIB_FFTW=...)</code> creates a temporary environment variable (called <code>local_LIB_FFTW</code>), which later parts of the R install process use to find the FFTW libraries.</p>
+<p>The <code>shortPathName</code> function (available only on Windows) converts “somepath” into a old-fashioned shorter version of “somepath” that Windows still recognises as the same directory, but which does not have blank spaces anywhere in the (shortened) pathname. Windows allows pathnames containing spaces but some older Unix commands did not deal well with blanks in pathnames, so I play safe and use the <code>shortPathName</code> function to avoid any possibility of those sort of errors.</p>
+<p>The environment variable disappears at the end of your R session (but it is tidy practice to remove it explicitly when the install step has finished using <code>Sys.unsetenv(&quot;local_LIB_FFTW&quot;)</code>)</p>
+</div>
+<div id="makefiles" class="section level3">
+<h3>Makefiles</h3>
+<p>As a package user, you do not need to know anything at all about this — it is all done for you — only package developers need to know this. But if you are curious, or in case something goes wrong and you need to figure out how to fix the problem, read on.</p>
+<p>The explanation of how R uses <code>local_LIB_FFTW</code> to complete the installation process is quite straightforward — but only <strong>once</strong> you know enough about how:</p>
+<ul>
+<li>the Unix based world uses <code>configure</code>, <code>make</code> and makefiles to improve the portability of programs written on lots of different systems,</li>
+<li>R uses a tailored version of that approach when it installs R packages, and</li>
+<li>R makes some special exceptions for installing packages from source on Windows based systems.</li>
+</ul>
+<p>The conventional way of installing programs from source in the Unix world involves a shell script (sort of like a Windows .bat file) called configure, and a program called <code>make</code> which reads instructions from a makefile. “Makefiles” are text files with a special format. Essentially they contain “rules”. Each rule tells the <code>make</code> program how to create and install a file. The file to be created is called a “target”. The next part of the rule is a list of “dependencies” (typically other files that must exist before the target can be created) and finally there are a list of 1 or more “recipes”, which are system (shell) commands that will be run to create the target once the dependencies exist. The make program analyses the makefile to discover the order in which various files must be created, then executes the necessary rules and their recipes in the right order. Typically recipes say things like (not in this syntax though!):</p>
+<ul>
+<li>“run the C pre-processor” (on this file), or</li>
+<li>“run the C compiler” (on this file and create an intermediate object file), or</li>
+<li>“link the following object files into an binary executable”, or</li>
+<li>“copy the executable file into this directory”</li>
+</ul>
+<p>To increase flexibility and readability, the <code>make</code> program also recognises and uses “make variables” in a makefile.</p>
+<p>This is of course a <em>gross</em> simplification, but the concept is correct. If you want to know a <em>little</em> more, see for example <a href="http://kbroman.org/minimal_make/">Minimal Make</a> and <a href="https://robots.thoughtbot.com/the-magic-behind-configure-make-make-install">The Magic behind configure, make, make install</a>.</p>
+<p>In fact the conventions surrounding configure and make, and the specifications for the syntax of a makefile, are so strong they are almost a standard, and there are literally books written about them. There are even programs (autotools) that will generate standard (very flexible, and hence very complex) “configure” and “makefile”s for you!</p>
+</div>
+<div id="srcmakevars.win" class="section level3">
+<h3>src/Makevars.win</h3>
+<p>Rtools includes a Windows version of a <code>make</code> program (ported from Unix), and the <code>R CMD INSTALL</code> command uses that <code>make</code> to install packages. Many makefiles are actually just called “Makefile”, but the <code>make</code> program accepts any name for a makefile, and indeed, will read in and combine several makefiles in one run, if so instructed.</p>
+<p>The <code>R CMD INSTALL</code> process uses a standard makefile called “Makeconf” (well “R_HOME/etcR_ARCH/Makeconf” to be precise), which does most of the work of compiling and installing <em>any</em> R package.</p>
+<p>But before reading Makeconf, <code>R CMD INSTALL</code> reads a package specific makefile called “Makevars” (well “src/Makevars” to be precise). The idea of the “Makevars” file is that package <strong>developers</strong> can use it to set some make variables (called <code>PKG_CPPFLAGS</code> and <code>PKG_LIBS</code>) that “Makeconf” expects, to whatever values their particular package needs. The variables, respectively, contain instructions (flags) for the C pre-processor and link stages of the installation process.</p>
+<p>Because Windows is “special” and often needs something different to most Unix systems , if <code>R CMD INSTALL</code> (or <code>install.packages</code>) detects that it is running on a Windows system, priority will be given to a “src/Makevars.win” if it is found, and the usual (Unix) Makevars file will be ignored.</p>
+<p>Rcartogram does have a “Makevars.win” file (you can find it in the src subdirectory), whose main purpose is to find the FFTW library, and put some required information into the <code>PKG_CPPFLAGS</code> and <code>PKG_LIBS</code> variables. One way that you, a package <strong>user</strong>, can tell “Makevars.win” where you put the FFTW libraries on your system is via a make variable that is defined and used in Rcartogram’s “Makevars.win”, called <code>local_LIB_FFTW</code>. There are numerous ways of setting a make variable, but one is by creating a system environment variable, of the same name, before invoking the <code>make</code> program. And that is what <code>Sys.setenv(local_LIB_FFTW=...)</code> does.</p>
+</div>
+</div>
+</div>
+<div id="alternative-approaches-supported-by-makevars.win" class="section level1">
+<h1>Alternative approaches supported by Makevars.win</h1>
+<hr />
+<p>The “src/Makevars.win” does support other ways of informing R where to find the FFTW libraries. It is extensively (almost overly) documented, if you care to read it.</p>
+<div id="alternative-use-the-win-builder-website-service" class="section level2">
+<h2>Alternative : Use the Win-Builder website service</h2>
+<p>There is another quite different approach, which uses the <a href="http://win-builder.r-project.org/">Win-Builder website service</a>, rather than compiling <code>Rcartogram</code> locally on your machine. The Win-Builder website:</p>
+<ul>
+<li>has the necessary C compiler,</li>
+<li>has (static versions of) the FFTW libraries already installed, and</li>
+<li>provides a make variable (called <code>LIB_FFTW</code>) which points to the location of the FFTW libraries.</li>
+</ul>
+<p>“Makevars.win” has been written to recognise and use <code>LIB_FFTW</code> if it is present (in preference to <code>local_LIB_FFTW</code>), so Rcartogram can be compiled simply by uploading the bundled source code of Rcartogram (with one <strong>crucial</strong> change) to the Win-Builder website site.</p>
+<p>This delegates all the work of steps 1 through 3 (ie compiling, linking, and preparing Windows binary versions of <code>Rcartogram</code>) to the service provided by the Winbuilder website. In a way, this is probably the simplest way of compiling a binary version of Rcartogram that can be installed on a Windows system.</p>
+<p>However the Win-Builder website service is intended more for infrequent use as a testing service by package developers who do <em>not</em> have access to a Windows system, rather than for regular use by package users who <em>do</em> have Windows, so it should be used only as a last resort, if the 3 step approach already described fails for some reason.</p>
+<p>There is one <strong>essential</strong> change you <strong>MUST</strong> make to Rcartogram, before you upload to the Win-Builder website.</p>
+<p>In the Rcartogram directory, there is a “DESCRIPTION” file. This is a text file, one line of which reads</p>
+<pre><code>Maintainer: Duncan Temple Lang &lt;duncan@wald.ucdavis.edu&gt;</code></pre>
+<p>You <strong>MUST</strong> edit this line to your own name and email address, and resave the “DESCRIPTION” file before using the Win-Builder website, since Win-Builder sends all the follow-up emails to that address. If it holds the wrong address, it will cause lots of annoyance for everyone!</p>
+<p>After you have edited and resaved the DESCRIPTION file, you can either:</p>
+<ol style="list-style-type: decimal">
+<li>rebundle the Rcartogram source code yourself manually (eg by using the <code>cmd</code> line <code>R CMD build</code> tool - type <code>R CMD build --help</code> for instructions), then upload the compressed file to the Win-Builder website using its web interface, or</li>
+<li><p>if you have the devtools package (available from CRAN) installed, you can start R, navigate to the Rcartogram folder, set that as your working directory, and enter into the console the line</p>
+<pre><code>devtools::build_win(&quot;.&quot;, args = &quot;--no-build-vignettes&quot;)</code></pre></li>
+</ol>
+<p>The <code>--no-build-vignettes</code> flag is necessary in <code>devtools::build_win</code> (and in <code>R CMD build &quot;.&quot;  --no-build-vignettes</code>), since otherwise R attempts to (temporarily) install Rcartogram <em>locally</em> so it can build the vignettes <em>before</em> uploading to the Win-builder website, which of course fails!</p>
+<p>In about 30-60 minutes, all being well, you will receive an email with a link to a temporary (it will be deleted in about 72 hours) directory on the the Win-Builder website where you will find a compiled binary version of Rcartogram, in a zip file.</p>
+<p>Download that zip file, start R, and then, from the R console, enter</p>
+<pre><code>install.packages(&quot;path to the zip file&quot;, repos = NULL)</code></pre>
+<p><code>type = source</code> is not necessary (in fact would be wrong), because this zip file contains the “usual” binary format files that <code>install.packages</code> expects on Windows.</p>
+</div>
+<div id="an-alternative-step-2-compile-fftw-itself-from-source" class="section level2">
+<h2>An alternative Step 2 : Compile FFTW itself from source</h2>
+<hr />
+<p>Step 2, as described earlier, obtained the FFTW libraries in precompiled binary format from the FFTW website. This alternative downloads the FFTW source code, and compiles the FFTW libraries locally.</p>
+<p>It enables you to specify that you want static (rather than dynamically loaded) versions of the FFTW libraries. The principal reason you might be interested in static FFTW libraries is to avoid any possibility of the <code>LoadLibrary failure:  The specified module could not be found.</code> error message which arises if Windows cannot find the FFTW DLL’s when Rcartogram “asks” for them..</p>
+<p>Compiling Rcartogram and linking to static FFTW libraries reduces slightly the complications later on, when you are actually using Rcartogram, but the gain is not great (since the Rcartogram install process and “Makevars.win” automatically takes care of the main complication involved in using dynamically linked versions of the FFTW libraries).</p>
+<p>In general I would not recommend this approach to a novice package installer. It involves more work (hence more possibility for something to go wrong).</p>
+<p>The process is only outlined below - it assumes some knowledge about using command lines shells under Windows.</p>
+<div id="download-and-decompress-the-fftw-source-code" class="section level3">
+<h3>1. Download and decompress the FFTW source code</h3>
+<p>The main FFTW website <a href="http://www.fftw.org/">FFTW — C code for Fast Fourier Transforms</a> contains a link to their <a href="http://www.fftw.org/download.html">FFTW downloads page</a>, which in turn contains a link which enables you to download a compressed version of the <a href="http://www.fftw.org/fftw-3.3.4.tar.gz">FFTW source code</a>.</p>
+<p>Download that source code and decompress it. Depending upon what version of Windows you are using, you may need a utility program to unzip and untar this file. I use 7zip, available for free from <a href="http://www.7-zip.org/download.html">7zip download page</a>.</p>
+<p>The FFTW website includes instructions about <a href="http://www.fftw.org/install/windows.html">Compiling FFTW on Windows</a>. You need to install some more tools ported from Unix to Windows onto your computer, so that you can run the :</p>
+<pre><code>./configure
+make
+make install</code></pre>
+<p><em>magic</em> incantation that is the standard approach to compiling code in the Unix universe.</p>
+<p>What follows is a modified version of the approach described on the FFTW website (modified because Rtools already provides the C compiler you will need).</p>
+</div>
+<div id="download-and-install-msys" class="section level3">
+<h3>2. Download and install MSys</h3>
+<p>Next install MSys on your computer. This website <a href="http://www.rioki.org/2013/10/16/mingw-w64.html">MinGW-w64 and MSys</a> contains a clear explanation of installing MinGW-w64 and MSys. You only need to download and install MSys. I put my downloaded and unzipped (untarred) version in “c:/msys”.</p>
+<p>Once done, you can invoke the <code>msys</code> shell at any time by typing <code>c:\msys\msys.bat</code> in a <code>cmd.exe</code> console. This opens a new <code>msys</code> console titled “MINGW32”.</p>
+<p>MSys is another “shell”, ported to Windows from the Unix world. It is tantalizingly similar to the usual Windows <code>cmd</code> shell, but with some commands and aspects of the syntax different enough to be confusing (if you are unfamiliar with them, as I was). The good news is you don’t really need to learn much about MSys to use it to install FFTW from source.</p>
+</div>
+<div id="point-msys-at-the-rtools-c-compiler" class="section level3">
+<h3>3. Point MSys at the Rtools C Compiler</h3>
+<p>Rather than downloading and installing MinGW-w64 (a C compiler), you can simply use the C compiler that comes with Rtools. You just have to tell the MSys shell where to find it. Do this by altering a line in the “c:/msys/etc/fstab” file, so it reads as follows:</p>
+<pre><code>    C:\Rtools\gcc-4.6.3    /mingw</code></pre>
+<p>Substitute :</p>
+<ul>
+<li>wherever you installed MSys for “C:/msys” to find the correct “etc/fstab” file, and</li>
+<li>wherever Rtools is on your system for “C:/Rtools/gcc-4.6.3” in the line in the fstab file.</li>
+</ul>
+<p>This tells the <code>msys</code> shell that when it is looking for directory <code>/mingw</code>, go to what Windows knows as the <code>C:\Rtools\gcc-4.6.3</code> directory. <code>/mingw</code> is where later steps will look for gcc, the GNU C compiler.</p>
+</div>
+<div id="compile-fftw-libraries-from-source" class="section level3">
+<h3>4. Compile FFTW libraries from source</h3>
+<p>Open the Msys shell, navigate to where the FFTW source is (use the <code>cd</code> command, which works under <code>msys</code> shell pretty similarly to the same command under the <code>cmd</code> shell), and enter the following lines.</p>
+<pre><code># exit if any error
+set -e
+
+#Use the standard architecture specific subdirectories, ie i386 for 32 bit, and x64 for 64 bit, in the prefixes.
+
+#64 bit version
+
+./configure CC=&quot;/mingw/bin/gcc -m64&quot; --prefix=/fftwtest/x64 --host=x86_64-w64-mingw32 --disable-alloca --with-our-malloc --with-windows-f77-mangling --disable-shared --enable-static --enable-threads --with-combined-threads --enable-sse2 --with-incoming-stack-boundary=2 &amp;&amp; make -j4 &amp;&amp; make install
+
+#32 bit version
+
+./configure CC=&quot;/mingw/bin/gcc -m32&quot; --prefix=/fftwtest/i386 --host=i386-w64-mingw32 --disable-alloca --with-our-malloc --with-windows-f77-mangling --disable-shared --enable-static --enable-threads --with-combined-threads --enable-sse2 --with-incoming-stack-boundary=2 &amp;&amp; make -j4 &amp;&amp; make install
+</code></pre>
+<p>To avoid typing errors, you could create a file in the FFTW directory (I called mine “geoffsfftw.txt”), cut and paste these lines into the file, and then execute it from the <code>msys</code> shell by entering <code>./geoffsfftw.txt</code> <strong>NB</strong> The sections beginning <code>./configure</code> through to <code>make install</code> all belong on a <strong>single</strong> line. In the text above they are wrapped, purely for readability purposes.</p>
+<p>This will compile both 32 and 64 bit versions of FFTW, as static libraries. It takes a while, and emits a lot of messages - there is easily time to take a break and have a cup of coffee or tea while the process is running.</p>
+<p>Most of the flags and instructions are copied verbatim from the the FFTW website instructions. The main differences are:</p>
+<ul>
+<li>the <code>-m64</code> in <code>CC=&quot;/mingw/bin/gcc -m64&quot;</code> tells the C compiler to compile 64 bit versions of the libraries; likewise <code>-m32</code> is for the 32 bit version. This is the feature that took me longest to discover.</li>
+<li><code>--prefix=/fftwtest/x64</code> and <code>--prefix=/fftwtest/i386</code> tell the make and make install processes where to place the FFTW libraries. These paths are relative to where msys is installed (so on my set up, an example of an absolute location was <code>c:/msys/fftwtest/x64</code>)</li>
+<li>the <code>--disable-shared --enable-static</code> flags say to compile and install static (rather than dynamic linked) versions of the FFTW libraries.</li>
+</ul>
+</div>
+<div id="continue-to-step-3-as-before-to-install-rcartogram" class="section level3">
+<h3>5. Continue to Step 3 (as before), to install Rcartogram</h3>
+<p>Rcartogram will compile and install quite happily using these static FFTW libraries as input to Step 3, described earlier. Just set the environment variable <code>local_LIB_FFTW</code> to point to the first part (excluding the architecture specific sub-directory) of the prefix - in my example I set <code>local_LIB_FFTW</code> to be <code>c:/msys/fftwtest</code>. The “src/Makevars.win” file even recognises and automatically takes care of the fact that under the GNU standard layout for files, there may be separate sub-directories below the architecture specific prefix level (“/include” for include files, “/lib” for library files, and so forth).</p>
+</div>
+</div>
+</div>
+
+
+
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
The pull request affects several files.  It is about installing Rcartogram from source on Windows.

The main change is to **src/Makevars.win**:
- it supports biarch (ie both 32 bit and 64 bit) installs on Windows
- it accepts and uses either DLL (dynamic linked library) or static versions of the FFTW libraries,
- if DLLs are provided, it copies them to the (appropriate sub-directory of the) Rcartogram directory in the users R library, at install time
- it discovers whether the fftw3 library is called libfftw3.something, or libfftw3-3.something, and provides the correct value (fftw3 or fftw3-3) in the -l flag to the link step
- it can be used to create Windows binary versions of Rcartogram using the Win-Builder website service, at http://win-builder.r-project.org/
- it accepts 3 alternative environment or make variables in order to learn where the fftw3 libraries are.  In order of decreasing preference (ie the first one found is used), they are:
  - LIB_FFTW - this is the name of the make variable that the Win-Builder website service provides to point to the fftw3 header and libraries
  - local_LIB_FFTW - this is the name of an environment variable that a package installer can set to point to their local copies of the fftw3 libraries. It's value should point to a directory which has 2 sub-directories, namely /i386 (containing the 32 bit version of the fftw3 library) and /x64 (containing the 64 bit version of the fftw3 library)
  - FFTW3_DIR - this is equivalent to local_LIB_FFTW, and is supported for compatibility with earlier versions of Makevars.win
- the fftw3.h header file and libfftw3 library file can either both be in the same sub-directory (eg /i386), or may be in sub-sub-directories (eg in /i386/include and /i386/lib).  Likewise for /x64.
- it emits messages informing the user what it has done
- it is heavily commented, in case a novice user wants to understand how it works

**configure.win** has been altered :
- it no longer copies the fftw3 DLLs (src/Makevars.win now does that, only if necessary)
- it emits a more expansive set of instructions if the environment variables pointing to the fftw3 library are absent.

**README.WindowsInstall** has been created:
- it contains step by step instructions for a novice Windows installer.

The **DESCRIPTION** file:
- now contains "Biarch: TRUE: - so that by default both 32 and 64 bit versions are installed, even though configure.win and src/Makevars.win exist.  This is mostly so the Win-Builder website knows to create both 32 and 64 bit binary Windows versions of Rcartogram.
- the version has been increased to 0.2-3 

A vignette called **vignettes/README.WindowsInstall.Tutorial.Rmd** (also provided in html format) has been added.
- It is a rather extensive tutorial about installing packages, specifically Rcartogram, from source on Windows.  It covers:
  - installing Rtools, downloading the fftw3 DLLs, and installing Rcartogram from source
  - using the Win-Builder website service to create Windows binary versions of Rcartogram, and
  - an outline of how to compile static versions of the FFTW3 libraries for Windows, by compiling FFTW3 itself from source

Finally, in **R/cart.R**
- predict.Cartogram has been very slightly modified to remove a problem whereby the y coordinates of the returned cartogram were overwriting the x coordinates (I suspect this was due to an interaction with R's (only) copy-on-modify semantics)
